### PR TITLE
Fix linting and naming errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # CF Services
-[![Go Reference](https://pkg.go.dev/badge/github.com/Piszmog/cfservices.svg)](https://pkg.go.dev/github.com/Piszmog/cfservices)
+[![Go Reference](https://pkg.go.dev/badge/github.com/Piszmog/cfservices.svg)](https://pkg.go.dev/github.com/Piszmog/cfservices/v2)
 [![Build Status](https://github.com/Piszmog/cfservices/workflows/Go/badge.svg)](https://github.com/Piszmog/cfservices/workflows/Go/badge.svg)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Piszmog_cfservices&metric=alert_status)](https://sonarcloud.io/dashboard?id=Piszmog_cfservices)
 [![Coverage Status](https://coveralls.io/repos/github/Piszmog/cfservices/badge.svg?branch=master)](https://coveralls.io/github/Piszmog/cfservices?branch=master)
-[![Go Report Card](https://goreportcard.com/badge/github.com/Piszmog/cfservices)](https://goreportcard.com/report/github.com/Piszmog/cfservices)
+[![Go Report Card](https://goreportcard.com/badge/github.com/Piszmog/cfservices)](https://goreportcard.com/report/github.com/Piszmog/cfservices/v2)
 [![GitHub release](https://img.shields.io/github/release/Piszmog/cfservices.svg)](https://github.com/Piszmog/cfservices/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 This library is aimed at removing the boilerplate code and let developers just worry about using actually connecting to 
 services they have bounded to their app.
 
-`go get github.com/Piszmog/cfservices`
+`go get github.com/Piszmog/cfservices/v2`
 
 ## Retrieving VCAP_SERVICES
 Simply use `cfservices.GetServices()`.
 
 ```go
 package main
-import "github.com/Piszmog/cfservices"
+import "github.com/Piszmog/cfservices/v2"
 
 func main() {
 	services, err := cfservices.GetServices()
@@ -36,7 +36,7 @@ instead.
 
 ```go
 package main
-import "github.com/Piszmog/cfservices"
+import "github.com/Piszmog/cfservices/v2"
 
 func main() {
 	var services map[string][]cfservices.Service

--- a/cfservices.go
+++ b/cfservices.go
@@ -27,19 +27,19 @@ type Service struct {
 
 // Credentials is the credentials of a single bounded services.
 type Credentials struct {
-	Uri            string                 `json:"uri"`
+	URI            string                 `json:"uri"`
 	JDBCUrl        string                 `json:"jdbcUrl"`
 	APIUri         string                 `json:"http_api_uri"`
 	LicenceKey     string                 `json:"licenseKey"`
 	ClientSecret   string                 `json:"client_secret"`
-	ClientId       string                 `json:"client_id"`
-	AccessTokenUri string                 `json:"access_token_uri"`
+	ClientID       string                 `json:"client_id"`
+	AccessTokenURI string                 `json:"access_token_uri"`
 	Hostname       string                 `json:"hostname"`
 	Username       string                 `json:"username"`
 	Password       string                 `json:"password"`
-	Port           json.Number            `json:"port"`
 	Name           string                 `json:"name"`
 	Additional     map[string]interface{} `json:"-"`
+	Port           json.Number            `json:"port"`
 }
 
 type _cred Credentials
@@ -91,14 +91,14 @@ func getServicesFromEnvironment() string {
 	return os.Getenv(VCAPServices)
 }
 
-// MissingServiceError is the error when the service does not exist in provided slice of services.
-var MissingServiceError = errors.New("service does not exist")
+// ErrMissingService is the error when the service does not exist in provided slice of services.
+var ErrMissingService = errors.New("service does not exist")
 
 // GetServiceCredentials retrieves the credentials for the specified service from the provided services.
 func GetServiceCredentials(services map[string][]Service, serviceName string) (*ServiceCredentials, error) {
 	service := services[serviceName]
 	if service == nil {
-		return nil, MissingServiceError
+		return nil, ErrMissingService
 	}
 	if len(service) == 0 {
 		return nil, fmt.Errorf("%s has no data", serviceName)

--- a/cfservices_test.go
+++ b/cfservices_test.go
@@ -2,10 +2,11 @@ package cfservices_test
 
 import (
 	"encoding/json"
-	"github.com/Piszmog/cfservices"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/Piszmog/cfservices/v2"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetUriCredentials(t *testing.T) {
@@ -24,7 +25,7 @@ func TestGetUriCredentials(t *testing.T) {
 	assert.NoError(t, err, "failed to unmarshal JSON")
 	credentials, err := cfservices.GetServiceCredentials(servicesJSON, "serviceA")
 	assert.NoError(t, err, "failed to get credentials")
-	assert.Equal(t, "example_uri", credentials.Credentials[0].Uri)
+	assert.Equal(t, "example_uri", credentials.Credentials[0].URI)
 }
 
 func TestGetUriCredentialsFromMultipleServices(t *testing.T) {
@@ -50,7 +51,7 @@ func TestGetUriCredentialsFromMultipleServices(t *testing.T) {
 	creds := serviceCred.Credentials
 	assert.Equal(t, 2, len(creds))
 	for _, cred := range creds {
-		assert.Equal(t, "example_uri", cred.Uri)
+		assert.Equal(t, "example_uri", cred.URI)
 	}
 }
 
@@ -114,13 +115,13 @@ func TestGetFullCredentials(t *testing.T) {
 	serviceCreds, err := cfservices.GetServiceCredentials(servicesJSON, "serviceA")
 	assert.NoError(t, err, "failed to get credentials")
 	expectedCredentials := cfservices.Credentials{
-		Uri:            "example_uri",
+		URI:            "example_uri",
 		JDBCUrl:        "jdbc:mysql:/url",
 		APIUri:         "example_httpAPIUri",
 		LicenceKey:     "example_licenseKey",
 		ClientSecret:   "example_clientSecret",
-		ClientId:       "example_clientId",
-		AccessTokenUri: "example_accessTokenUri",
+		ClientID:       "example_clientId",
+		AccessTokenURI: "example_accessTokenUri",
 		Hostname:       "example_hostname",
 		Username:       "example_username",
 		Password:       "example_password",
@@ -176,7 +177,7 @@ func TestGetUriCredentialsFromEnv(t *testing.T) {
 	defer os.Unsetenv(cfservices.VCAPServices)
 	credentials, err := cfservices.GetServiceCredentialsFromEnvironment("serviceA")
 	assert.NoError(t, err, "failed to get credentials")
-	assert.Equal(t, "example_uri", credentials.Credentials[0].Uri)
+	assert.Equal(t, "example_uri", credentials.Credentials[0].URI)
 }
 
 func TestGetUriCredentialsFromMultipleServicesInEnv(t *testing.T) {
@@ -202,7 +203,7 @@ func TestGetUriCredentialsFromMultipleServicesInEnv(t *testing.T) {
 	creds := serviceCred.Credentials
 	assert.Equal(t, 2, len(creds))
 	for _, cred := range creds {
-		assert.Equal(t, "example_uri", cred.Uri)
+		assert.Equal(t, "example_uri", cred.URI)
 	}
 }
 
@@ -277,12 +278,12 @@ func TestGetFullCredentialsInEnv(t *testing.T) {
 	serviceCreds, err := cfservices.GetServiceCredentialsFromEnvironment("serviceA")
 	assert.NoError(t, err, "failed to get credentials")
 	expectedCredentials := cfservices.Credentials{
-		Uri:            "example_uri",
+		URI:            "example_uri",
 		APIUri:         "example_httpAPIUri",
 		LicenceKey:     "example_licenseKey",
 		ClientSecret:   "example_clientSecret",
-		ClientId:       "example_clientId",
-		AccessTokenUri: "example_accessTokenUri",
+		ClientID:       "example_clientId",
+		AccessTokenURI: "example_accessTokenUri",
 		Hostname:       "example_hostname",
 		Username:       "example_username",
 		Password:       "example_password",

--- a/examples/cred/main.go
+++ b/examples/cred/main.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/Piszmog/cfservices"
 	"log"
+
+	"github.com/Piszmog/cfservices/v2"
 )
 
 func main() {
@@ -12,7 +13,7 @@ func main() {
 			{
 				Name: "Service A",
 				Credentials: cfservices.Credentials{
-					Uri: "example_uri",
+					URI: "example_uri",
 				},
 			},
 		},

--- a/examples/environment/main.go
+++ b/examples/environment/main.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/Piszmog/cfservices"
 	"os"
+
+	"github.com/Piszmog/cfservices/v2"
 )
 
 func main() {

--- a/examples/services/main.go
+++ b/examples/services/main.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/Piszmog/cfservices"
 	"os"
+
+	"github.com/Piszmog/cfservices/v2"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Piszmog/cfservices
+module github.com/Piszmog/cfservices/v2
 
 go 1.20
 


### PR DESCRIPTION
See #59.

Fixes naming errors and to ensure backwards compatibility, the packages has been upgraded to V2